### PR TITLE
Allow insecure certs

### DIFF
--- a/config/cantaloupe.properties
+++ b/config/cantaloupe.properties
@@ -144,7 +144,7 @@ FilesystemSource.lookup_strategy = ScriptLookupStrategy
 # HttpSource
 #----------------------------------------
 
-HttpSource.trust_all_certs = true
+HttpSource.allow_insecure = true
 HttpSource.request_timeout = 300
 
 # Tells the Jetty HTTP client which cipher suites to exclude.


### PR DESCRIPTION
The docs show `allow_insecure` instead of `trust_all_certs`