### PR TITLE
Pass encoded spaces in names in URI

### DIFF
--- a/config/delegates.rb
+++ b/config/delegates.rb
@@ -159,14 +159,14 @@ class CustomDelegate
     namespace, identifier = identifier_parts()
 
     log('source switch statement, identifier: ' + identifier, 'trace')
-    # This flag is meant for local and acceptance environment to only allow accessing 
+    # This flag is meant for local and acceptance environment to only allow accessing
     # the filesystem
     if ENV['USE_LOCAL_SOURCE'] == 'false' then
       source = 'HttpSource'
     else
       source = 'FilesystemSource'
     end
-    
+
     log('using source: ' + source, 'debug')
     source
   end
@@ -218,7 +218,7 @@ class CustomDelegate
   #
   def httpsource_resource_info(options = {})
     namespace, identifier = identifier_parts()
-    
+
     # TODO: read base URIs from config file, see commit 850c9fd38b1072b2a4374f45cd810fad12bd45e8 for load_props code
     case namespace
     when 'objectstore'
@@ -227,16 +227,14 @@ class CustomDelegate
       return "https://beeldbank.amsterdam.nl/component/ams_memorixbeeld_download/?format=download&id=#{identifier}"
     when 'edepot'
       identifier = identifier.gsub('-', '/')
-      uri = URI.decode(identifier)
       return {
-        "uri" => EDEPOT_BASE_URL + uri,
+        "uri" => EDEPOT_BASE_URL + identifier,
         "headers" => {"Authorization" => ENV['HCP_AUTHORIZATION']}
       }
     when 'wabo'
       identifier = identifier.gsub('-', '/')
-      uri = URI.decode(identifier)
       return {
-        "uri" => WABO_BASE_URL + uri,
+        "uri" => WABO_BASE_URL + identifier,
         "headers" => {"Host" => "conversiestraatwabo.amsterdam.nl"}
       }
     end

--- a/scripts/run_test_local.sh
+++ b/scripts/run_test_local.sh
@@ -15,8 +15,16 @@ echo ""
  ./config/delegates_test.rb 'edepot:SA-00702-SA00632608_00001.jpg' "https://bwt.uitplaatsing.hcp-a.basis.lan/rest/SA/00702/SA00632608_00001.jpg"
  echo ""
 
+echo "## edepot resolution with space in name"
+ ./config/delegates_test.rb 'edepot:SA-00702%20(2)-SA00632608_00001.jpg' "https://bwt.uitplaatsing.hcp-a.basis.lan/rest/SA/00702%20(2)/SA00632608_00001.jpg"
+ echo ""
+
  echo "## wabo resolution"
  ./config/delegates_test.rb 'wabo:SDC-DOCUMENTUM-PRIMARY-27-0901B69980392066.PDF' "http://127.0.0.1:50000/webDAV/SDC/DOCUMENTUM/PRIMARY/27/0901B69980392066.PDF"
+ echo ""
+
+ echo "## wabo resolution with space in name"
+ ./config/delegates_test.rb 'wabo:SDW-ACTIVITY_DOCS-Procesinformatie%20sdw_51322878.pdf/info.json' "http://127.0.0.1:50000/webDAV/SDW/ACTIVITY_DOCS/Procesinformatie%20sdw_51322878.pdf/info.json"
  echo ""
 
  echo "## beeldbank resolution"


### PR DESCRIPTION
Do not call decode for URI because then encoded spaces are replaced by
spaces