### PR TITLE
Handle spaces in the URL correctly

### DIFF
--- a/config/delegates.rb
+++ b/config/delegates.rb
@@ -227,14 +227,16 @@ class CustomDelegate
       return "https://beeldbank.amsterdam.nl/component/ams_memorixbeeld_download/?format=download&id=#{identifier}"
     when 'edepot'
       identifier = identifier.gsub('-', '/')
+      uri = URI.encode(identifier)
       return {
-        "uri" => EDEPOT_BASE_URL + identifier,
+        "uri" => EDEPOT_BASE_URL + uri,
         "headers" => {"Authorization" => ENV['HCP_AUTHORIZATION']}
       }
     when 'wabo'
       identifier = identifier.gsub('-', '/')
+      uri = URI.encode(identifier)
       return {
-        "uri" => WABO_BASE_URL + identifier,
+        "uri" => WABO_BASE_URL + uri,
         "headers" => {"Host" => "conversiestraatwabo.amsterdam.nl"}
       }
     end

--- a/scripts/run_test_local.sh
+++ b/scripts/run_test_local.sh
@@ -16,7 +16,7 @@ echo ""
  echo ""
 
 echo "## edepot resolution with space in name"
- ./config/delegates_test.rb 'edepot:SA-00702%20(2)-SA00632608_00001.jpg' "https://bwt.uitplaatsing.hcp-a.basis.lan/rest/SA/00702%20(2)/SA00632608_00001.jpg"
+ ./config/delegates_test.rb 'edepot:SA-00702 (2)-SA00632608_00001.jpg' "https://bwt.uitplaatsing.hcp-a.basis.lan/rest/SA/00702%20(2)/SA00632608_00001.jpg"
  echo ""
 
  echo "## wabo resolution"
@@ -24,7 +24,7 @@ echo "## edepot resolution with space in name"
  echo ""
 
  echo "## wabo resolution with space in name"
- ./config/delegates_test.rb 'wabo:SDW-ACTIVITY_DOCS-Procesinformatie%20sdw_51322878.pdf/info.json' "http://127.0.0.1:50000/webDAV/SDW/ACTIVITY_DOCS/Procesinformatie%20sdw_51322878.pdf/info.json"
+ ./config/delegates_test.rb 'wabo:SDW-ACTIVITY_DOCS-Procesinformatie sdw_51322878.pdf/info.json' "http://127.0.0.1:50000/webDAV/SDW/ACTIVITY_DOCS/Procesinformatie%20sdw_51322878.pdf/info.json"
  echo ""
 
  echo "## beeldbank resolution"


### PR DESCRIPTION
Before a URL is passed to delegates.rb encoded spaces are decoded to
real spaces. So we use  URI.encode  to conver real spaces again to
%20 encodes spaces.